### PR TITLE
Fixed typo and use FDV for clarity

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -45,7 +45,7 @@
                         <td id="txt-price-change24" class="injected">Fetching data . . .</td>
                     </tr>
                     <tr>
-                        <td>Diluited Market Cap.:</td>
+                        <td>Fully Diluted Valuation:</td>
                         <td id="txt-diluited-market-cap" class="injected">Fetching data . . .</td>
                     </tr>
                     <tr>


### PR DESCRIPTION
I fixed the typo in "Diluited" and change the term to the more commonly used FDV.